### PR TITLE
Several changes for PBv2 testing

### DIFF
--- a/src/libGPIB/AMAC.cpp
+++ b/src/libGPIB/AMAC.cpp
@@ -31,10 +31,17 @@ int AMAC::read(AMACreg reg, unsigned &val){
 		case AMACreg::VALUE_RIGHT_CH3: 	return this->readBits(32,10,6, val);
 		case AMACreg::VALUE_RIGHT_CH4: 	return this->readBits(34,10,0, val);
 		case AMACreg::VALUE_RIGHT_CH5: 	return this->readBits(35,10,2, val);
-		case AMACreg::VALUE_RIGHT_CH6: 	return this->readBits(36,10,4, val);	
-		case AMACreg::HV_ENABLE:	return this->readBits(43,1,0,val);	
-		case AMACreg::LV_ENABLE:	return this->readBits(44,1,0,val);
-		case AMACreg::HV_FREQ:		return this->readBits(43,2,1,val);
+		case AMACreg::VALUE_RIGHT_CH6: 	return this->readBits(36,10,4, val);
+		case AMACreg::LEFT_RAMP_GAIN: 	return this->readBits(45,2,0, val);
+		case AMACreg::RIGHT_RAMP_GAIN: 	return this->readBits(45,2,4, val);
+		case AMACreg::OPAMP_GAIN_RIGHT:	return this->readBits(42,4,4, val);
+		case AMACreg::OPAMP_GAIN_LEFT:	return this->readBits(42,4,0, val);
+		case AMACreg::BANDGAP_CONTROL: 	return this->readBits(40,5,0, val);
+		case AMACreg::RT_CH3_GAIN_SEL: 	return this->readBits(45,1,7, val);
+		case AMACreg::LT_CH3_GAIN_SEL: 	return this->readBits(45,1,3, val);
+		case AMACreg::HV_ENABLE:	return this->readBits(43,1,0, val);	
+		case AMACreg::LV_ENABLE:	return this->readBits(44,1,0, val);
+		case AMACreg::HV_FREQ:		return this->readBits(43,2,1, val);
 		case AMACreg::ILOCK_FLAG_HV_LEFT_HI:	return this->readBits(1,7,0,val);
 		case AMACreg::ILOCK_FLAG_HV_LEFT_LO:	return this->readBits(2,7,0,val);
 		case AMACreg::ILOCK_FLAG_HV_RIGHT_HI:	return this->readBits(3,7,0,val);
@@ -67,6 +74,7 @@ int AMAC::read(AMACreg reg, unsigned &val){
 		case AMACreg::WARN_EN_LV_LEFT_LO:	return this->readBits(63,7,0,val);
 		case AMACreg::WARN_EN_LV_RIGHT_HI:	return this->readBits(64,7,0,val);
 		case AMACreg::WARN_EN_LV_RIGHT_LO:	return this->readBits(65,7,0,val);
+		case AMACreg::ILOCK_HV_THRESH_HI_L_CH0:	return this->readBits(66,10,0,val);
 		default:
 			return -2; break;
 	}
@@ -76,13 +84,13 @@ int AMAC::read(AMACreg reg, unsigned &val){
 int AMAC::write(AMACreg reg, unsigned val){
 	switch(reg){
 		case AMACreg::LEFT_RAMP_GAIN: 		return this->writeBits(45,2,0,val);	
-		case AMACreg::RIGHT_RAMP_GAIN: 		return this->writeBits(45,2,4,val);	
+		case AMACreg::RIGHT_RAMP_GAIN: 		return this->writeBits(45,2,4,val);
 		case AMACreg::OPAMP_GAIN_RIGHT:		return this->writeBits(42,4,4,val);
 		case AMACreg::OPAMP_GAIN_LEFT:		return this->writeBits(42,4,0,val);
-		case AMACreg::BANDGAP_CONTROL: 		return this->writeBits(40,5,0,val);		
-		case AMACreg::RT_CH3_GAIN_SEL: 		return this->writeBits(45,1,7,val);		
-		case AMACreg::LT_CH3_GAIN_SEL: 		return this->writeBits(45,1,3,val);		
-		case AMACreg::RT_CH0_SEL: 		return this->writeBits(45,1,6,val);		
+	        case AMACreg::BANDGAP_CONTROL: 		return this->writeBits(40,5,0,val);
+		case AMACreg::RT_CH3_GAIN_SEL: 		return this->writeBits(45,1,7,val);
+		case AMACreg::LT_CH3_GAIN_SEL: 		return this->writeBits(45,1,3,val);
+		case AMACreg::RT_CH0_SEL: 		return this->writeBits(45,1,6,val);
 		case AMACreg::LT_CH0_SEL: 		return this->writeBits(45,1,2,val);	
 		case AMACreg::CLK_OUT_ENABLE : 		return this->writeBits(41,1,0,val);	
 		case AMACreg::CLK_SELECT:		return this->writeBits(49,1,0,val);	

--- a/src/libGPIB/AgilentPs.cpp
+++ b/src/libGPIB/AgilentPs.cpp
@@ -54,6 +54,11 @@ void AgilentPs::setVoltage(double volt) {
     this->send("VOLTAGE " + std::to_string(volt));
 }
 
+std::string AgilentPs::getVoltage() {
+    std::string result=this->receive("MEAS:VOLT?");
+    return result.substr(0, result.length()-2);
+}
+
 void AgilentPs::setCurrent(double cur) {
     this->send("CURRENT " + std::to_string(cur));
 }

--- a/src/libGPIB/include/AgilentPs.h
+++ b/src/libGPIB/include/AgilentPs.h
@@ -24,6 +24,7 @@ class AgilentPs {
         void setCh(unsigned ch);
         void setRange(unsigned range);
         void setVoltage(double volt);
+        std::string getVoltage();
         void setCurrent(double cur);
         std::string getCurrent();
         void turnOn();

--- a/src/libGalil/CMakeLists.txt
+++ b/src/libGalil/CMakeLists.txt
@@ -1,11 +1,18 @@
-# Add the headers
-include_directories( include )
+# Check for OpenCV
+find_package( OpenCV QUIET )
 
-# Add all *.c* files as source code
-file(GLOB SrcFiles *.c*)
-add_library(Galil SHARED ${SrcFiles}) 
-if(APPLE)
-target_link_libraries(Galil /Applications/gclib/dylib/gclib.0.dylib /Applications/gclib/dylib/gclibo.0.dylib)
+if ( ${OpenCV_FOUND} )
+  # Add the headers
+  include_directories( include )
+
+  # Add all *.c* files as source code
+  file(GLOB SrcFiles *.c*)
+  add_library(Galil SHARED ${SrcFiles}) 
+  if(APPLE)
+    target_link_libraries(Galil /Applications/gclib/dylib/gclib.0.dylib /Applications/gclib/dylib/gclibo.0.dylib)
+  else()
+    target_link_libraries(Galil gclib gclibo)
+  endif()
 else()
-target_link_libraries(Galil gclib gclibo)
+  message("Disabling libGalil due to missing OpenCV")
 endif()

--- a/src/libWaferProb/CMakeLists.txt
+++ b/src/libWaferProb/CMakeLists.txt
@@ -1,10 +1,16 @@
-# Add the headers
-include_directories( include )
-include_directories( ../libGalil/include )
-include_directories( ../libZaber/include )
+# Check for OpenCV
+find_package( OpenCV QUIET )
 
-# Add all *.c* files as source code
-file(GLOB SrcFiles *.c*)
-add_library(WaferProb SHARED ${SrcFiles}) 
-target_link_libraries(WaferProb Galil Zaber)
-#add_dependencies(WaferProb libGalil libZaber)
+if ( ${OpenCV_FOUND} )
+  # Add the headers
+  include_directories( include )
+  include_directories( ../libGalil/include )
+  include_directories( ../libZaber/include )
+
+  # Add all *.c* files as source code
+  file(GLOB SrcFiles *.c*)
+  add_library(WaferProb SHARED ${SrcFiles}) 
+  target_link_libraries(WaferProb Galil Zaber)
+else()
+  message("Disabling libWaferProb due to missing OpenCV")
+endif()

--- a/src/pbv2/CMakeLists.txt
+++ b/src/pbv2/CMakeLists.txt
@@ -5,7 +5,9 @@ include_directories( ../libGPIB/include )
 #link_libraries( GPIB )
 
 # add executables
-file(GLOB tools *.c*)
+file(GLOB tools [a-zA-Z]*.c[a-zA-Z]*)
+
+
 foreach(target ${tools})
   get_filename_component(execname ${target} NAME_WE)
   get_filename_component(srcfile ${target} NAME)

--- a/src/pbv2/pbv2_monitor.cpp
+++ b/src/pbv2/pbv2_monitor.cpp
@@ -1,0 +1,181 @@
+#include <iostream>
+#include <fstream>
+#include <cmath>
+
+#include <sys/stat.h>
+#include <dirent.h>
+
+#include "Logger.h"
+#include "MojoCom.h"
+#include "I2CCom.h"
+#include "AMAC.h"
+#include "Bk85xx.h"
+#include "AgilentPs.h"
+#include "Keithley24XX.h"
+
+loglevel_e loglevel = logINFO;
+
+int main(int argc, char* argv[]) {
+  //
+  // Get settings from the command line
+  if (argc < 5) {
+    log(logERROR) << "Not enough parameters!";
+    log(logERROR) << "Useage: " << argv[0] << " TESTNAME <Mojo> <BK85XX> <GPIB>";
+    return -1;
+  }
+
+  std::string TestName = argv[1];
+  std::string mojoDev = argv[2];
+  std::string bkDev = argv[3];
+  std::string gpibDev = argv[4];
+
+  //
+  // Create log directory if it does not exist
+  DIR* logdir=opendir("log");
+  if(!logdir)
+    {
+      const int dir_err = mkdir("log", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+      if (-1 == dir_err)
+	{
+	  std::cerr << "Error creating log directory!" << std::endl;
+	  return 1;
+	}
+    }
+  else
+    closedir(logdir);
+
+  //
+  // Run tests
+  log(logINFO) << "Initialising ...";
+    
+  log(logINFO) << " ... Agilent PS:";
+  AgilentPs ps(gpibDev, 10);
+  ps.init();
+  ps.setRange(20);
+  ps.setVoltage(11.0);
+  ps.setCurrent(2.00);
+  ps.turnOn();
+  std::this_thread::sleep_for(std::chrono::seconds(5));
+
+  log(logINFO) << " ... Keithley 2410:";
+  Keithley24XX sm(gpibDev, 9);
+  sm.init();
+  sm.setSource(KeithleyMode::CURRENT, 1e-6, 1e-6);
+  sm.setSense(KeithleyMode::VOLTAGE, 500, 500);
+
+  log(logINFO) << " ... DC Load:";
+  Bk85xx dc(bkDev);
+  dc.setRemote();
+  dc.setRemoteSense();
+  dc.setModeCC();
+  dc.setCurrent(0);
+  //dc.turnOn();
+
+  log(logINFO) << " ... AMAC:";
+  MojoCom mojo(mojoDev);
+  AMAC amac(0, dynamic_cast<I2CCom*>(&mojo));
+
+  log(logINFO) << "  ++Init";
+  amac.write(AMACreg::BANDGAP_CONTROL, 10); //1.2V LDO output
+  amac.write(AMACreg::RT_CH3_GAIN_SEL, 0); // no attenuation
+  amac.write(AMACreg::LT_CH3_GAIN_SEL, 0); // no attentuation
+  amac.write(AMACreg::RT_CH0_SEL, 1); //a
+  amac.write(AMACreg::LT_CH0_SEL, 1); //a 
+  amac.write(AMACreg::LEFT_RAMP_GAIN, 3); // best range
+  amac.write(AMACreg::RIGHT_RAMP_GAIN, 3); // best range
+  amac.write(AMACreg::OPAMP_GAIN_RIGHT, 0); // highest gain
+  amac.write(AMACreg::OPAMP_GAIN_LEFT, 0); // highest gain
+  amac.write(AMACreg::HV_FREQ, 0x1);
+
+  log(logINFO) << "  ++Enable LV";
+  amac.write(AMACreg::LV_ENABLE, 0x0);
+  log(logINFO) << "  ++Disable HV";
+  amac.write(AMACreg::HV_ENABLE, 0x0);
+
+  //dc.setCurrent(1);
+
+
+  log(logINFO) << "  ++ Const ADC values:";
+  unsigned ota_l, ota_r, bgo, dvdd2;
+  amac.read(AMACreg::VALUE_LEFT_CH5, ota_l);
+  std::cout << "OTA_LEFT : \t" << ota_l << std::endl;
+  amac.read(AMACreg::VALUE_RIGHT_CH5, ota_r);
+  std::cout << "OTA_RIGHT : \t" << ota_r << std::endl;
+  amac.read(AMACreg::VALUE_LEFT_CH1, dvdd2);
+  std::cout << "DVDD/2 : \t" << dvdd2 << std::endl;
+  amac.read(AMACreg::VALUE_LEFT_CH2, bgo);
+  std::cout << "BGO : \t" << bgo << std::endl;
+
+
+  //
+  // Run monitoring
+  std::string logpath = "log/" + TestName + "_monitor.log";
+  std::fstream logfile(logpath, std::fstream::out);
+    logfile << "time bgo rtch3gain ltch3gain rtrg ltrg rtog ltog hvfreq ch0la ch0lb ch1l ch2l ch3l ch4l ch5l ch6l ch0ra ch0rb ch1r ch2r ch3r ch4r ch5r ch6r" << std::endl;
+
+  log(logINFO) << "Start monitoring...";
+
+  unsigned ch0la,ch0lb,ch1l,ch2l,ch3l,ch4l,ch5l,ch6l;
+  unsigned ch0ra,ch0rb,ch1r,ch2r,ch3r,ch4r,ch5r,ch6r;
+  unsigned ctl_bgo, ctl_rtch3gain, ctl_ltch3gain, ctl_rtrg, ctl_ltrg, ctl_rtog, ctl_ltog, ctl_hvfreq;
+  for(uint i=0;i<100000;i++)
+    {
+      auto time = std::chrono::system_clock::now();
+
+      logfile << std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch()).count();
+
+      // Check settings
+      ctl_bgo=ctl_rtch3gain=ctl_ltch3gain=ctl_rtrg=ctl_ltrg=ctl_rtog=ctl_ltog=ctl_hvfreq=0;
+      amac.read(AMACreg::BANDGAP_CONTROL, ctl_bgo);
+      amac.read(AMACreg::RT_CH3_GAIN_SEL, ctl_rtch3gain);
+      amac.read(AMACreg::LT_CH3_GAIN_SEL, ctl_ltch3gain);
+      amac.read(AMACreg::LEFT_RAMP_GAIN,  ctl_rtrg);
+      amac.read(AMACreg::RIGHT_RAMP_GAIN, ctl_ltrg);
+      amac.read(AMACreg::OPAMP_GAIN_RIGHT,ctl_rtog);
+      amac.read(AMACreg::OPAMP_GAIN_LEFT, ctl_ltog);
+      amac.read(AMACreg::HV_FREQ,         ctl_hvfreq);
+
+      logfile << " " << ctl_bgo << " " << ctl_rtch3gain << " " << ctl_ltch3gain << " " << ctl_rtrg << " " << ctl_ltrg << " " << ctl_rtog << " " << ctl_ltog << " " << ctl_hvfreq;
+
+      // check ADCs
+      ch0la=ch0lb=ch1l=ch2l=ch3l=ch4l=ch5l=ch6l=0;
+      ch0ra=ch0rb=ch1r=ch2r=ch3r=ch4r=ch5r=ch6r=0;
+
+      amac.write(AMACreg::LT_CH0_SEL, 0);
+      amac.read(AMACreg::VALUE_LEFT_CH0, ch0la);
+      amac.write(AMACreg::LT_CH0_SEL, 1);
+      amac.read(AMACreg::VALUE_LEFT_CH0, ch0lb);
+      amac.read(AMACreg::VALUE_LEFT_CH1, ch1l);
+      amac.read(AMACreg::VALUE_LEFT_CH2, ch2l);
+      amac.read(AMACreg::VALUE_LEFT_CH3, ch3l);
+      amac.read(AMACreg::VALUE_LEFT_CH4, ch4l);
+      amac.read(AMACreg::VALUE_LEFT_CH5, ch5l);
+      amac.read(AMACreg::VALUE_LEFT_CH6, ch6l);
+
+      amac.write(AMACreg::RT_CH0_SEL, 0);
+      amac.read(AMACreg::VALUE_RIGHT_CH0, ch0ra);
+      amac.write(AMACreg::RT_CH0_SEL, 1);
+      amac.read(AMACreg::VALUE_RIGHT_CH0, ch0rb);
+      amac.read(AMACreg::VALUE_RIGHT_CH1, ch1r);
+      amac.read(AMACreg::VALUE_RIGHT_CH2, ch2r);
+      amac.read(AMACreg::VALUE_RIGHT_CH3, ch3r);
+      amac.read(AMACreg::VALUE_RIGHT_CH4, ch4r);
+      amac.read(AMACreg::VALUE_RIGHT_CH5, ch5r);
+      amac.read(AMACreg::VALUE_RIGHT_CH6, ch6r);
+
+      logfile << " " << ch0la << " " << ch0lb << " " << ch1l << " " << ch2l << " " << ch3l << " " << ch4l << " " << ch5l << " " << ch6l
+	      << " " << ch0ra << " " << ch0rb << " " << ch1r << " " << ch2r << " " << ch3r << " " << ch4r << " " << ch5r << " " << ch6r
+	      << std::endl;
+
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+
+  //
+  // Poweroff
+  sm.turnOff();
+  ps.turnOff();
+  dc.turnOff();
+
+  return 0;
+}

--- a/src/pbv2/pbv2_monitor.cpp
+++ b/src/pbv2/pbv2_monitor.cpp
@@ -55,7 +55,6 @@ int main(int argc, char* argv[]) {
   ps.setVoltage(11.0);
   ps.setCurrent(2.00);
   ps.turnOn();
-  std::this_thread::sleep_for(std::chrono::seconds(5));
 
   log(logINFO) << " ... Keithley 2410:";
   Keithley24XX sm(gpibDev, 9);
@@ -96,7 +95,7 @@ int main(int argc, char* argv[]) {
 
 
   log(logINFO) << "  ++ Const ADC values:";
-  unsigned ota_l, ota_r, bgo, dvdd2;
+  unsigned ota_l=0, ota_r=0, bgo=0, dvdd2=0;
   amac.read(AMACreg::VALUE_LEFT_CH5, ota_l);
   std::cout << "OTA_LEFT : \t" << ota_l << std::endl;
   amac.read(AMACreg::VALUE_RIGHT_CH5, ota_r);
@@ -111,7 +110,7 @@ int main(int argc, char* argv[]) {
   // Run monitoring
   std::string logpath = "log/" + TestName + "_monitor.log";
   std::fstream logfile(logpath, std::fstream::out);
-    logfile << "time bgo rtch3gain ltch3gain rtrg ltrg rtog ltog hvfreq ch0la ch0lb ch1l ch2l ch3l ch4l ch5l ch6l ch0ra ch0rb ch1r ch2r ch3r ch4r ch5r ch6r" << std::endl;
+  logfile << "time bgo rtch3gain ltch3gain rtrg ltrg rtog ltog hvfreq ch0la ch0lb ch1l ch2l ch3l ch4l ch5l ch6l ch0ra ch0rb ch1r ch2r ch3r ch4r ch5r ch6r" << std::endl;
 
   log(logINFO) << "Start monitoring...";
 

--- a/src/pbv2/pbv2_poweroff.cpp
+++ b/src/pbv2/pbv2_poweroff.cpp
@@ -1,0 +1,95 @@
+#include <iostream>
+#include <cmath>
+
+#include "Logger.h"
+#include "MojoCom.h"
+#include "I2CCom.h"
+#include "AMAC.h"
+#include "Bk85xx.h"
+#include "AgilentPs.h"
+#include "Keithley24XX.h"
+
+loglevel_e loglevel = logINFO;
+
+int main(int argc, char* argv[]) {
+
+    if (argc < 4) {
+        log(logERROR) << "Not enough parameters!";
+        log(logERROR) << "Useage: " << argv[0] << " <Mojo> <BK85XX> <GPIB>";
+        return -1;
+    }
+
+    std::string mojoDev = argv[1];
+    std::string bkDev = argv[2];
+    std::string gpibDev = argv[3];
+
+    log(logINFO) << "Initialising ...";
+    
+    log(logINFO) << " ... Agilent PS:";
+    AgilentPs ps(gpibDev, 10);
+    ps.init();
+    ps.setRange(20);
+    ps.setVoltage(11.0);
+    ps.setCurrent(2.00);
+    ps.turnOn();
+
+    log(logINFO) << " ... Keithley 2410:";
+    Keithley24XX sm(gpibDev, 9);
+    sm.init();
+    sm.setSource(KeithleyMode::CURRENT, 1e-6, 1e-6);
+    sm.setSense(KeithleyMode::VOLTAGE, 500, 500);
+
+    log(logINFO) << " ... DC Load:";
+    Bk85xx dc(bkDev);
+    dc.setRemote();
+    dc.setRemoteSense();
+    dc.setModeCC();
+    dc.setCurrent(0);
+    dc.turnOn();
+  
+    log(logINFO) << " ... AMAC:";
+    MojoCom mojo(mojoDev);
+    AMAC amac(0, dynamic_cast<I2CCom*>(&mojo));
+    
+
+    sm.turnOff();
+    ps.turnOff();
+    dc.turnOff();
+    
+    /*
+    log(logINFO) << "  ++ADC Values";
+    unsigned val = 0;
+    amac.read(AMACreg::VALUE_RIGHT_CH0, val);
+    log(logINFO) << "[VIN] : \t" << val ;
+    amac.read(AMACreg::VALUE_RIGHT_CH1, val);
+    log(logINFO) << "[IOUT] : \t" << val ;
+    amac.read(AMACreg::VALUE_RIGHT_CH2, val);
+    log(logINFO) << "[NTC_Temp] : \t" << val ;
+    amac.read(AMACreg::VALUE_RIGHT_CH3, val);
+    log(logINFO) << "[3R] : \t\t" << val ;
+    amac.read(AMACreg::VALUE_RIGHT_CH4, val);
+    log(logINFO) << "[VDD_H/4] : \t" << val ;
+    amac.read(AMACreg::VALUE_RIGHT_CH5, val);
+    log(logINFO) << "[OTA] : \t" << val ;
+    amac.read(AMACreg::VALUE_RIGHT_CH6, val);
+    log(logINFO) << "[ICHANR] : \t" << val ;
+    
+    amac.read(AMACreg::VALUE_LEFT_CH0, val);
+    log(logINFO) << "[0L] : \t\t" << val ;
+    amac.read(AMACreg::VALUE_LEFT_CH1, val);
+    log(logINFO) << "[DVDD/2] : \t" << val ;
+    amac.read(AMACreg::VALUE_LEFT_CH2, val);
+    log(logINFO) << "[BGO] : \t" << val ;
+    amac.read(AMACreg::VALUE_LEFT_CH3, val);
+    log(logINFO) << "[3L] : \t\t" << val ;
+    amac.read(AMACreg::VALUE_LEFT_CH4, val);
+    log(logINFO) << "[TEMP] : \t" << val ;
+    amac.read(AMACreg::VALUE_LEFT_CH5, val);
+    log(logINFO) << "[OTA] : \t" << val ;
+    amac.read(AMACreg::VALUE_LEFT_CH6, val);
+    log(logINFO) << "[ICHANL] : \t" << val ;
+
+    */
+
+    return 0;
+}

--- a/src/prober/CMakeLists.txt
+++ b/src/prober/CMakeLists.txt
@@ -1,23 +1,27 @@
-include_directories( ../libGalil/include )
-include_directories( ../libZaber/include )
-include_directories( ../libWaferProb/include )
-
-# add one exectable foreach 
-add_executable(eg_galil eg_galil.cpp)
-target_link_libraries(eg_galil Galil WaferProb)
-
-add_executable(eg_zaber eg_zaber.cpp)
-target_link_libraries(eg_zaber Zaber)
-
-add_executable(motion_controller motion_controller.cpp)
-target_link_libraries(motion_controller Galil Zaber WaferProb)
-
+# Check for OpenCV
 find_package( OpenCV QUIET )
-if ( ${OpenCV_FOUND} )
-	include_directories( ../libImageRec/include )
-	add_executable(test_opencv_camera test_opencv_camera.cpp)
-	target_link_libraries(test_opencv_camera ${OpenCV_LIBS})
 
-	add_executable(test_sift test_sift.cpp)
-	target_link_libraries(test_sift ImageRec ${OpenCV_LIBS})
+if ( ${OpenCV_FOUND} )
+  include_directories( ../libGalil/include )
+  include_directories( ../libZaber/include )
+  include_directories( ../libWaferProb/include )
+
+  # add one exectable foreach 
+  add_executable(eg_galil eg_galil.cpp)
+  target_link_libraries(eg_galil Galil WaferProb)
+
+  add_executable(eg_zaber eg_zaber.cpp)
+  target_link_libraries(eg_zaber Zaber)
+
+  add_executable(motion_controller motion_controller.cpp)
+  target_link_libraries(motion_controller Galil Zaber WaferProb)
+
+  include_directories( ../libImageRec/include )
+  add_executable(test_opencv_camera test_opencv_camera.cpp)
+  target_link_libraries(test_opencv_camera ${OpenCV_LIBS})
+
+  add_executable(test_sift test_sift.cpp)
+  target_link_libraries(test_sift ImageRec ${OpenCV_LIBS})
+else()
+  message("Disabling prober due to missing OpenCV")
 endif()

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,9 +1,16 @@
-# add executables
-file(GLOB tools *.c*)
-foreach(target ${tools})
-  get_filename_component(execname ${target} NAME_WE)
-  get_filename_component(srcfile ${target} NAME)
-  add_executable(${execname} ${srcfile})
-  add_dependencies(${execname} libGPIB)
-  set_target_properties(${execname} PROPERTIES LINKER_LANGUAGE CXX)
-endforeach()
+# Check for OpenCV
+find_package( OpenCV QUIET )
+
+if ( ${OpenCV_FOUND} )
+  # add executables
+  file(GLOB tools *.c*)
+  foreach(target ${tools})
+    get_filename_component(execname ${target} NAME_WE)
+    get_filename_component(srcfile ${target} NAME)
+    add_executable(${execname} ${srcfile})
+    add_dependencies(${execname} libGPIB)
+    set_target_properties(${execname} PROPERTIES LINKER_LANGUAGE CXX)
+  endforeach()
+else()
+  message("Disabling tools due to missing OpenCV")
+endif()


### PR DESCRIPTION
* Add getVoltage to AgilentPs, to read the voltage...
* Add `pbv2_monitor` for long term monitoring of a powerboard
* Add `pbv2_poweroff` that turns off all supplies. This is hack to turn off everything when a test is prematurely terminated. Should implement proper clean-up.
* Add the control registers to AMAC::read.
* Disable anything that depends on galil if OpenCV is not found (aka all probe station code). Ideally should write a FindGalil module and disable the modules then...