### PR TITLE
Add support for I2C communication via FT232H

### DIFF
--- a/cmake/Findlibmpsse.cmake
+++ b/cmake/Findlibmpsse.cmake
@@ -1,0 +1,23 @@
+# - Try to find libmpsse
+# Once done this will define
+#  LIBMPSSE_FOUND - System has libmpsse
+#  LIBMPSSE_INCLUDE_DIRS - The libmpsse include directories
+#  LIBMPSSE_LIBRARIES - The libraries needed to use libmpsse
+#  LIBMPSSE_DEFINITIONS - Compiler switches required for using libmpsse
+
+FIND_PATH(LIBMPSSE_INCLUDE_DIR mpsse.h
+          HINTS /usr/include)
+
+FIND_LIBRARY(LIBMPSSE_LIBRARY NAMES mpsse libmpsse
+              HINTS /usr/lib64 )
+
+INCLUDE(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set LIBMPSSE_FOUND to TRUE
+# if all listed variables are TRUE
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(libmpsse  DEFAULT_MSG
+  LIBMPSSE_LIBRARY LIBMPSSE_INCLUDE_DIR)
+
+MARK_AS_ADVANCED(LIBMPSSE_INCLUDE_DIR LIBMPSSE_LIBRARY )
+
+SET(LIBMPSSE_LIBRARIES ${LIBMPSSE_LIBRARY} )
+SET(LIBMPSSE_INCLUDE_DIRS ${LIBMPSSE_INCLUDE_DIR} )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,24 @@ add_compile_options(-Wall)
 add_compile_options(-fPIC)
 
 #
+# Check dependencies
+# Find libFTDI1
+find_package ( LibFTDI1 QUIET )
+
+# Find libmpsse
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+find_package ( libmpsse QUIET )
+
+if ( (${LIBFTDI_FOUND}) AND (${LIBMPSSE_FOUND}) )
+  set(ENABLE_FTDI 1)
+else()
+  message("Disabling FTDI code due to missing libftdi1 or libmpsse")
+  message(" libftdi1 = ${LIBFTDI_FOUND}")
+  message(" libmpsse = ${LIBMPSSE_FOUND}")
+endif()
+
+
+#
 # Add libraries
 add_subdirectory(libGPIB)
 add_subdirectory(libGalil)

--- a/src/libGPIB/CMakeLists.txt
+++ b/src/libGPIB/CMakeLists.txt
@@ -1,6 +1,33 @@
+#
+# Look for dependencies
+
+# Find libFTDI1
+
+#
+# Prepare the library
+
 # Add the headers
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/include )
 
 # Add all *.c* files as source code
-file(GLOB SrcFiles *.c*)
+set(SrcFiles AgilentPs.cpp
+  AMAC.cpp
+  Bk85xx.cpp
+  Keithley24XX.cpp
+  MojoCom.cpp
+  SerialCom.cpp)
+
+if ( ${ENABLE_FTDI} )
+  set(SrcFiles ${SrcFiles}
+    FTDICom.cpp)
+
+  include_directories ( ${LIBFTDI_INCLUDE_DIR} ${LIBMPSSE_INCLUDE_DIR} )
+  link_directories ( ${LIBFTDI_LIBRARY_DIRS} ${LIBMPSSE_LIBRARIES} )
+else()
+  message("skipping FTDICom due to missing libftdi1 or libmpsse")
+  message(" libftdi1 = ${LIBFTDI_FOUND}")
+  message(" libmpsse = ${LIBMPSSE_FOUND}")
+endif()
+
 add_library(GPIB SHARED ${SrcFiles}) 
+target_link_libraries(GPIB mpsse ftdi1)

--- a/src/libGPIB/FTDICom.cpp
+++ b/src/libGPIB/FTDICom.cpp
@@ -1,0 +1,75 @@
+#include "FTDICom.h"
+
+extern "C"{
+#include <mpsse.h>
+}
+
+#include <string.h>
+#include <unistd.h>
+
+FTDICom::FTDICom()
+  : m_i2cdev(0)
+{  }
+
+FTDICom::~FTDICom()
+{ }
+
+int FTDICom::enableI2C()
+{ 
+  if(m_i2cdev!=0) return 0;
+  if((m_i2cdev=MPSSE(I2C, ONE_HUNDRED_KHZ, MSB)) == NULL || !m_i2cdev->open) return 1;
+  
+  log(logDEBUG2) << __PRETTY_FUNCTION__ << "I2C device "<< GetDescription(m_i2cdev) << " initialized at " << GetClock(m_i2cdev) << "Hz";
+
+  Tristate(m_i2cdev);
+      
+  return 0;
+}
+
+int FTDICom::readI2C(unsigned id, unsigned addr, char *data, unsigned bytes)
+{
+  char buf[1] = {0};
+  char *outbuf=new char[bytes];
+
+  if(Start(m_i2cdev)!=0) return -1;
+
+  buf[0]=id<<1;
+  if(Write(m_i2cdev, buf, 1)!=0) return -2;
+  buf[0]=addr;
+  if(Write(m_i2cdev, buf, 1)!=0) return -3;
+
+  if(GetAck(m_i2cdev)==ACK)
+    {
+      if(Start(m_i2cdev)!=0) return -5;
+      buf[0]=(id<<1)|1;
+      if(Write(m_i2cdev, buf, 1)!=0) return -6;
+
+      SendAcks(m_i2cdev);
+      outbuf=Read(m_i2cdev, bytes);
+      SendNacks(m_i2cdev);
+      Read(m_i2cdev, 1); // dummy read to send the NACK
+      strncpy(data,outbuf,bytes);
+    }
+  else return -4;
+
+  if(Stop(m_i2cdev)!=0) return -7;
+
+  return 0;
+}
+
+int FTDICom::writeI2C(unsigned id, unsigned addr, char *data, unsigned bytes)
+{
+  char buf[1];
+
+  if(Start(m_i2cdev)!=0) return -1;
+
+  buf[0]=id<<1;
+  if(Write(m_i2cdev, buf, 1)!=0) return -2;
+  buf[0]=addr;
+  if(Write(m_i2cdev, buf, 1)!=0) return -3;
+  if(Write(m_i2cdev, data, bytes)!=0) return -4;
+
+  if(Stop(m_i2cdev)!=0) return -5;
+
+  return 0;
+}

--- a/src/libGPIB/MojoCom.cpp
+++ b/src/libGPIB/MojoCom.cpp
@@ -1,20 +1,24 @@
 #include "MojoCom.h"
 
 MojoCom::MojoCom(std::string dev) {
-    m_com = new SerialCom(dev, B115200);
-    // Reset
-    
-    char obuf[2] = {'\n', '\r'};
-    char ibuf[2] = {' ', ' '};
-    for (unsigned n=0; n<10; n++) {
-        m_com->write(obuf, 2);
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        for (unsigned i=0; i<2; i+=m_com->read(&ibuf[i], 2-i))
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        if (ibuf[1] != '\n') {
-            log(logERROR) << __PRETTY_FUNCTION__ << " : Reset failed!";
-        }
+  m_com = new SerialCom(dev, B115200);
+  // Reset
+
+  char obuf[] = "\r\n";
+  char ibuf[2];
+  for (unsigned n=0; n<10; n++) {
+    m_com->write(obuf, 2);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    for (unsigned i=0; i<2; i+=m_com->read(&ibuf[i], 2-i))
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    if (ibuf[1] != '\n') {
+      log(logERROR) << __PRETTY_FUNCTION__ << " : Reset failed!";
+    } else {
+      break;
     }
+  }
 }
 
 MojoCom::~MojoCom() {
@@ -22,80 +26,65 @@ MojoCom::~MojoCom() {
 }
 
 int MojoCom::writeReg(unsigned reg, unsigned val) {
-    log(logDEBUG1) << __PRETTY_FUNCTION__ << " : reg(" << reg << ") val(" << val << ")";
-    char outbuf[7], inbuf[4];
+  log(logDEBUG1) << __PRETTY_FUNCTION__ << " : reg(" << reg << ") val(" << val << ")";
+  char outbuf[7], inbuf[4];
 
-    // Prepare buffer
-    outbuf[0] = 0x80 | ((reg >> 8) & 0xFF);
-    outbuf[1] = reg & 0xFF;
-    outbuf[2] = (val >> 24 ) & 0xFF;
-    outbuf[3] = (val >> 16 ) & 0xFF;
-    outbuf[4] = (val >> 8 ) & 0xFF;
-    outbuf[5] = val & 0xFF;
-    outbuf[6] = '\n';
+  // Prepare buffer
+  outbuf[0] = 0x80 | ((reg >> 8) & 0xFF);
+  outbuf[1] = reg & 0xFF;
+  outbuf[2] = (val >> 24 ) & 0xFF;
+  outbuf[3] = (val >> 16 ) & 0xFF;
+  outbuf[4] = (val >> 8 ) & 0xFF;
+  outbuf[5] = val & 0xFF;
+  outbuf[6] = '\n';
 
-    // Write buffer
-    if (m_com->write(outbuf, 7) < 7) {
-        log(logERROR) << __PRETTY_FUNCTION__ << " : Failed writing all bytes!";
-        return -1;
-    }
-    // Read status
-    
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    for (unsigned i=0; i<2; i+=m_com->read(&inbuf[i], 2-i))
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    /*
-    if (m_com->read(inbuf, 2) < 2) {
-        log(logERROR) << __PRETTY_FUNCTION__ << " : Failed reading status bytes!";
-        return -1;
-    }
-    */
-    // Check status
-    if (((inbuf[0] & 0xF) > 0) || (inbuf[1] != '\n')) {
-        log(logERROR) << __PRETTY_FUNCTION__<< " : Status signals error!";
-        return -1;
-    }
+  // Write buffer
+  if (m_com->write(outbuf, 7) < 7) {
+    log(logERROR) << __PRETTY_FUNCTION__ << " : Failed writing all bytes!";
+    return -1;
+  }
 
-    return 0;
+  return 0;
 }
 
 int MojoCom::readReg(unsigned reg, unsigned &val) {
-    log(logDEBUG1) << __PRETTY_FUNCTION__ << " : reg(" << reg << ")";
-    char outbuf[3], inbuf[8];
+  log(logDEBUG1) << __PRETTY_FUNCTION__ << " : reg(" << reg << ")";
+  char outbuf[3], inbuf[6];
 
-    // Prepare output
-    outbuf[0] = 0x00 | ((reg >> 8) & 0xFF);
-	outbuf[1] = reg & 0xFF;
-	outbuf[2] = '\n';
+  // Prepare output
+  outbuf[0] = 0x00 | ((reg >> 8) & 0xFF);
+  outbuf[1] = reg & 0xFF;
+  outbuf[2] = '\n';
 
-    // Write output
-    if (m_com->write(outbuf, 3) < 3) return -1;
-    // Read status
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    for (unsigned i=0; i<2; i+=m_com->read(&inbuf[i], 2-i))
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    
-    //if (m_com->read(inbuf, 2) < 2) return -1;
-    // Check status
-    if (!(inbuf[0] & 0x8)) return -1;
-   
-    // Read data
-    for (unsigned i=0; i<4; i+=m_com->read(&inbuf[2+i], 4-i))
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    //if (m_com->read(&inbuf[2], 4) < 4) return -1;
-    // Check status
-    if (inbuf[5] != '\n') return -1;
-    // Trasnfer data
-    for(int i = 1; i < 5; i++) val = (val<<8) + (unsigned char)inbuf[i];
-    log(logDEBUG1) << __PRETTY_FUNCTION__ << " : val(" << val << ")";
-    return 0;
+  // Write output
+  if (m_com->write(outbuf, 3) < 3) 
+    {
+      log(logERROR) << __PRETTY_FUNCTION__ << " : Failed writing all bytes!";
+      return -1;
+    }
+
+  // Read data
+  for (unsigned i=0; i<6; i+=m_com->read(&inbuf[i], 6-i))
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+  // Check status
+  if (inbuf[5] != '\n')
+    {
+      log(logERROR) << __PRETTY_FUNCTION__ << " : Wrong read response!";
+      return -1;
+    }
+
+  // Trasnfer data
+  for(int i = 1; i < 5; i++) val = (val<<8) + (unsigned char)inbuf[i];
+  log(logDEBUG1) << __PRETTY_FUNCTION__ << " : val(" << val << ")";
+  return 0;
 }
 
 int MojoCom::enableI2C() {
     log(logINFO) << __PRETTY_FUNCTION__ << " : Enabling I2C!";
     // Reset I2C
-    if (this->writeReg(0x4c, 0x0))  return -1;
-    if (this->writeReg(0x4c, 0x03)) return -1; // unreset I2C + drive SCL active
+    if (this->writeReg(0x4c, 0x00))  return -1;
+    if (this->writeReg(0x4c, 0x01)) return -1; // unreset I2C + drive SCL active
 
     // Set the I2C clock prescale
     if (this->writeReg(0x100, 0x00)) return -1;
@@ -109,105 +98,105 @@ int MojoCom::enableI2C() {
 int MojoCom::readI2C(unsigned id, unsigned addr, unsigned *data, unsigned bytes) {
     unsigned i(0), reg(0);
 
-	// Write Slave Address(RW = W) + Start Condition
-	if(writeReg(0x103, id<<1)) return -1;
-	if(writeReg(0x104,0x90)) return -1;
-	do{
-		usleep(1000);
-		if(readReg(0x104, reg)) return -1;
-	}while(reg & 0x02);
-	if(reg != 0x41)
-		return -1;
+    // Write Slave Address(RW = W) + Start Condition
+    if(writeReg(0x103, id<<1)) return -1;
+    if(writeReg(0x104,0x90)) return -1;
+    do{
+      usleep(1000);
+      if(readReg(0x104, reg)) return -1;
+    }while(reg & 0x02);
+    if(reg != 0x41)
+      return -1;
 
-	// Write Register Address
-	if(writeReg(0x103, addr)) return -1;
-	if(writeReg(0x104,0x10)) return -1;
-	do{
-		usleep(1000);
-		if(readReg(0x104, reg)) return -1;
-	}while(reg & 0x02);
-	if(reg != 0x41)
-		return -1;
-
-	// Write Slave Address(RW = R) + Repeated Start Condition
-	if(writeReg(0x103, id*2+1)) return -1;
-	if(writeReg(0x104,0x90)) return -1;
-	do{
-		usleep(1000);
-		if(readReg(0x104, reg)) return -1;
-	}while(reg & 0x02);
-	if(reg != 0x41)
-		return -1;
-
-	// Read Bytes
-	for(i = 0; i < (bytes - 1); i++){;
-		if(writeReg(0x104,0x20)) return -1;
-		do{
-			usleep(1000);
-			if(readReg(0x104, reg)) return -1;
-		}while(reg & 0x02);
-		if(reg != 0x41)
-			return -1;
-		if(readReg(0x103, data[i])) return -1;
-	}
-
-	// Read last byte + Stop Condition & NACK
-	if(writeReg(0x104,0x68)) return -1;
-	do{
-		usleep(1000);
-		if(readReg(0x104, reg)) return -1;
-	}while(reg & 0x02);
-	if(reg != 0x81)
-		return -1;
-	if(readReg(0x103, data[i])) return -1;
-
-	return 0;
-}
-
-int MojoCom::writeI2C(unsigned id, unsigned addr, unsigned *data, unsigned bytes) {
-	unsigned i(0), reg(0);
-
-    // Write id + Start Condition
-	if(writeReg(0x103, id<<1)) return -1;
-	if(writeReg(0x104,0x90)) return -1;
-	do{
-		usleep(1000);
-		if(readReg(0x104, reg)) return -1;
-	}while(reg & 0x02);
-	if(reg != 0x41)
-		return -1;
-
-    // Write reg addr
+    // Write Register Address
     if(writeReg(0x103, addr)) return -1;
     if(writeReg(0x104,0x10)) return -1;
     do{
-        usleep(1000);
-        if(readReg(0x104, reg)) return -1;
+      usleep(1000);
+      if(readReg(0x104, reg)) return -1;
     }while(reg & 0x02);
     if(reg != 0x41)
-        return -1;
+      return -1;
 
-	// Write Bytes
-	for(i = 0; i < (bytes-1); i++){
-		if(writeReg(0x103, data[i])) return -1;
-		if(writeReg(0x104,0x10)) return -1;
-		do{
-			usleep(1000);
-			if(readReg(0x104, reg)) return -1;
-		}while(reg & 0x02);
-		if(reg != 0x41)
-			return -1;
-	}
+    // Write Slave Address(RW = R) + Repeated Start Condition
+    if(writeReg(0x103, id*2+1)) return -1;
+    if(writeReg(0x104,0x90)) return -1;
+    do{
+      usleep(1000);
+      if(readReg(0x104, reg)) return -1;
+    }while(reg & 0x02);
+    if(reg != 0x41)
+      return -1;
+
+    // Read Bytes
+    for(i = 0; i < (bytes - 1); i++){;
+      if(writeReg(0x104,0x20)) return -1;
+      do{
+	usleep(1000);
+	if(readReg(0x104, reg)) return -1;
+      }while(reg & 0x02);
+      if(reg != 0x41)
+	return -1;
+      if(readReg(0x103, data[i])) return -1;
+    }
+
+    // Read last byte + Stop Condition & NACK
+    if(writeReg(0x104,0x68)) return -1;
+    do{
+      usleep(1000);
+      if(readReg(0x104, reg)) return -1;
+    }while(reg & 0x02);
+    if(reg != 0x81)
+      return -1;
+    if(readReg(0x103, data[i])) return -1;
+
+    return 0;
+}
+
+int MojoCom::writeI2C(unsigned id, unsigned addr, unsigned *data, unsigned bytes) {
+  unsigned i(0), reg(0);
+
+  // Write id + Start Condition
+  if(writeReg(0x103, id<<1)) return -1;
+  if(writeReg(0x104,0x90)) return -1;
+  do{
+    usleep(1000);
+    if(readReg(0x104, reg)) return -1;
+  }while(reg & 0x02);
+  if(reg != 0x41)
+    return -1;
+
+  // Write reg addr
+  if(writeReg(0x103, addr)) return -1;
+  if(writeReg(0x104,0x10)) return -1;
+  do{
+    usleep(1000);
+    if(readReg(0x104, reg)) return -1;
+  }while(reg & 0x02);
+  if(reg != 0x41)
+    return -1;
+
+  // Write Bytes
+  for(i = 0; i < (bytes-1); i++){
+    if(writeReg(0x103, data[i])) return -1;
+    if(writeReg(0x104,0x10)) return -1;
+    do{
+      usleep(1000);
+      if(readReg(0x104, reg)) return -1;
+    }while(reg & 0x02);
+    if(reg != 0x41)
+      return -1;
+  }
 	
-	// Write Byte + Stop Condition
-	if(writeReg(0x103, data[i])) return -1;
-	if(writeReg(0x104,0x50)) return -1;
-	do{
-		usleep(1000);
-		if(readReg(0x104, reg)) return -1;
-	}while(reg & 0x02);
-	if(reg != 0x01)
-		return -1;
+  // Write Byte + Stop Condition
+  if(writeReg(0x103, data[i])) return -1;
+  if(writeReg(0x104,0x50)) return -1;
+  do{
+    usleep(1000);
+    if(readReg(0x104, reg)) return -1;
+  }while(reg & 0x02);
+  if(reg != 0x01)
+    return -1;
 
-	return 0;
+  return 0;
 }

--- a/src/libGPIB/MojoCom.cpp
+++ b/src/libGPIB/MojoCom.cpp
@@ -27,7 +27,7 @@ MojoCom::~MojoCom() {
 
 int MojoCom::writeReg(unsigned reg, unsigned val) {
   log(logDEBUG1) << __PRETTY_FUNCTION__ << " : reg(" << reg << ") val(" << val << ")";
-  char outbuf[7], inbuf[4];
+  char outbuf[7];
 
   // Prepare buffer
   outbuf[0] = 0x80 | ((reg >> 8) & 0xFF);

--- a/src/libGPIB/MojoCom.cpp
+++ b/src/libGPIB/MojoCom.cpp
@@ -25,7 +25,7 @@ MojoCom::~MojoCom() {
     delete m_com;
 }
 
-int MojoCom::writeReg(unsigned reg, unsigned val) {
+int MojoCom::writeReg(unsigned reg, char val) {
   log(logDEBUG1) << __PRETTY_FUNCTION__ << " : reg(" << reg << ") val(" << val << ")";
   char outbuf[7];
 
@@ -47,7 +47,7 @@ int MojoCom::writeReg(unsigned reg, unsigned val) {
   return 0;
 }
 
-int MojoCom::readReg(unsigned reg, unsigned &val) {
+int MojoCom::readReg(unsigned reg, char &val) {
   log(logDEBUG1) << __PRETTY_FUNCTION__ << " : reg(" << reg << ")";
   char outbuf[3], inbuf[6];
 
@@ -95,8 +95,9 @@ int MojoCom::enableI2C() {
     return 0;
 }
 
-int MojoCom::readI2C(unsigned id, unsigned addr, unsigned *data, unsigned bytes) {
-    unsigned i(0), reg(0);
+int MojoCom::readI2C(unsigned id, unsigned addr, char *data, unsigned bytes) {
+    unsigned i(0);
+    char reg(0);
 
     // Write Slave Address(RW = W) + Start Condition
     if(writeReg(0x103, id<<1)) return -1;
@@ -153,8 +154,9 @@ int MojoCom::readI2C(unsigned id, unsigned addr, unsigned *data, unsigned bytes)
     return 0;
 }
 
-int MojoCom::writeI2C(unsigned id, unsigned addr, unsigned *data, unsigned bytes) {
-  unsigned i(0), reg(0);
+int MojoCom::writeI2C(unsigned id, unsigned addr, char *data, unsigned bytes) {
+  unsigned i(0);
+  char reg(0);
 
   // Write id + Start Condition
   if(writeReg(0x103, id<<1)) return -1;

--- a/src/libGPIB/include/AMAC.h
+++ b/src/libGPIB/include/AMAC.h
@@ -1,21 +1,23 @@
 #ifndef AMAC_H
 #define AMAC_H
 
+#include <memory>
 #include <iostream>
+
 #include "I2CCom.h"
 
 enum class AMACreg;
 
 class AMAC {
     public:
-        AMAC(unsigned id, I2CCom *i2c);
+        AMAC(unsigned id, std::unique_ptr<I2CCom>& i2c);
         ~AMAC();
 
         int read(AMACreg reg, unsigned &val);
         int write(AMACreg reg, unsigned val);
     private:
         unsigned m_id;
-        I2CCom *m_i2c;
+	std::unique_ptr<I2CCom> m_i2c;
 
         int readBits(unsigned startreg, unsigned num_bits, unsigned offset, unsigned &value);
         int writeBits(unsigned startreg, unsigned num_bits, unsigned offset, unsigned value);

--- a/src/libGPIB/include/FTDICom.h
+++ b/src/libGPIB/include/FTDICom.h
@@ -1,0 +1,27 @@
+#ifndef FTDICOM_H
+#define FTDICOM_H
+
+#include <iostream>
+#include <thread>
+#include <chrono>
+#include <string>
+
+#include "I2CCom.h"
+#include "Logger.h"
+
+struct mpsse_context;
+
+class FTDICom : public I2CCom {
+public:
+  FTDICom();
+  ~FTDICom();
+
+  int enableI2C();
+  int writeI2C(unsigned id, unsigned addr, char *data, unsigned bytes);
+  int readI2C(unsigned id, unsigned addr, char *data, unsigned bytes);
+
+private:
+  struct mpsse_context *m_i2cdev;
+};
+
+#endif

--- a/src/libGPIB/include/I2CCom.h
+++ b/src/libGPIB/include/I2CCom.h
@@ -4,8 +4,8 @@
 class I2CCom {
     public:
         virtual int enableI2C() = 0;
-        virtual int writeI2C(unsigned id, unsigned addr, unsigned *data, unsigned bytes) = 0;
-        virtual int readI2C(unsigned id, unsigned addr, unsigned *data, unsigned bytes) = 0;
+        virtual int writeI2C(unsigned id, unsigned addr, char *data, unsigned bytes) = 0;
+        virtual int readI2C(unsigned id, unsigned addr, char *data, unsigned bytes) = 0;
 };
 
 #endif

--- a/src/libGPIB/include/MojoCom.h
+++ b/src/libGPIB/include/MojoCom.h
@@ -16,14 +16,14 @@ class MojoCom : public I2CCom {
         ~MojoCom();
 
         int enableI2C();
-        int writeI2C(unsigned id, unsigned addr, unsigned *data, unsigned bytes);
-        int readI2C(unsigned id, unsigned addr, unsigned *data, unsigned bytes);
+        int writeI2C(unsigned id, unsigned addr, char *data, unsigned bytes);
+        int readI2C(unsigned id, unsigned addr, char *data, unsigned bytes);
     protected:
     private:
         SerialCom *m_com;
 
-        int writeReg(unsigned reg, unsigned val);
-        int readReg(unsigned reg, unsigned &val);
+        int writeReg(unsigned reg, char val);
+        int readReg(unsigned reg, char &val);
 
 };
 

--- a/src/pbv2/CMakeLists.txt
+++ b/src/pbv2/CMakeLists.txt
@@ -1,20 +1,18 @@
 # add global dependencies
 include_directories( ../libGPIB/include )
+link_directories( ${CMAKE_BINARY_DIR}/lib )
 
-# preferred to use target_link_libraries
-#link_libraries( GPIB )
+if( ${ENABLE_FTDI} )
+  add_definitions(-DFTDI)
+endif()
 
 # add executables
 file(GLOB tools [a-zA-Z]*.c[a-zA-Z]*)
-
 
 foreach(target ${tools})
   get_filename_component(execname ${target} NAME_WE)
   get_filename_component(srcfile ${target} NAME)
 
   add_executable(${execname} ${srcfile})
-  target_link_libraries(${execname} GPIB)
-  # seems reduntant
-  #add_dependencies(${execname} libGPIB)
-  
+  target_link_libraries(${execname} -lGPIB)
 endforeach()

--- a/src/pbv2/pbv2_i2c.cpp
+++ b/src/pbv2/pbv2_i2c.cpp
@@ -1,0 +1,171 @@
+#include <iostream>
+#include <fstream>
+#include <cmath>
+
+#include <sys/stat.h>
+#include <dirent.h>
+
+#ifdef FTDI
+#include "FTDICom.h"
+#endif
+
+#include "Logger.h"
+#include "MojoCom.h"
+#include "I2CCom.h"
+#include "AMAC.h"
+#include "Bk85xx.h"
+#include "AgilentPs.h"
+#include "Keithley24XX.h"
+
+loglevel_e loglevel = logINFO;
+
+int main(int argc, char* argv[]) {
+  //
+  // Get settings from the command line
+  if (argc < 5) {
+    log(logERROR) << "Not enough parameters!";
+    log(logERROR) << "Usage: " << argv[0] << " TESTNAME <Mojo/FTDI> <BK85XX> <GPIB>";
+    return -1;
+  }
+
+  std::string TestName = argv[1];
+  std::string mojoDev = argv[2];
+  std::string bkDev = argv[3];
+  std::string gpibDev = argv[4];
+
+#ifndef FTDI
+  if(mojoDev=="FTDI")
+    {
+      log(logERROR) << "FTDI support not enabled.";
+      return -1;
+    }
+#endif
+
+  //
+  // Create log directory if it does not exist
+  DIR* logdir=opendir("log");
+  if(!logdir)
+    {
+      const int dir_err = mkdir("log", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+      if (-1 == dir_err)
+	{
+	  std::cerr << "Error creating log directory!" << std::endl;
+	  return 1;
+	}
+    }
+  else
+    closedir(logdir);
+
+  //
+  // Run tests
+  log(logINFO) << "Initialising ...";
+
+  log(logINFO) << " ... Agilent PS:";
+  AgilentPs ps(gpibDev, 10);
+  ps.init();
+  ps.setRange(20);
+  ps.setVoltage(11.0);
+  ps.setCurrent(2.00);
+  ps.turnOn();
+
+  log(logINFO) << " ... Keithley 2410:";
+  Keithley24XX sm(gpibDev, 9);
+  sm.init();
+  sm.setSource(KeithleyMode::CURRENT, 1e-6, 1e-6);
+  sm.setSense(KeithleyMode::VOLTAGE, 500, 500);
+
+  log(logINFO) << " ... DC Load:";
+  Bk85xx dc(bkDev);
+  dc.setRemote();
+  dc.setRemoteSense();
+  dc.setModeCC();
+  dc.setCurrent(0);
+  dc.turnOn();
+
+  std::unique_ptr<I2CCom> i2c;
+#ifdef FTDI
+  if(mojoDev=="FTDI")
+    i2c.reset(new FTDICom());
+  else
+    i2c.reset(new MojoCom(mojoDev));
+#else
+  i2c.reset(new MojoCom(mojoDev));
+#endif
+  AMAC amac(0, i2c);
+
+  log(logINFO) << "  ++Init";
+  amac.write(AMACreg::BANDGAP_CONTROL, 10); //1.2V LDO output
+  amac.write(AMACreg::RT_CH3_GAIN_SEL, 0); // no attenuation
+  amac.write(AMACreg::LT_CH3_GAIN_SEL, 0); // no attentuation
+  amac.write(AMACreg::RT_CH0_SEL, 1); //a
+  amac.write(AMACreg::LT_CH0_SEL, 1); //a 
+  amac.write(AMACreg::LEFT_RAMP_GAIN, 3); // best range
+  amac.write(AMACreg::RIGHT_RAMP_GAIN, 3); // best range
+  amac.write(AMACreg::OPAMP_GAIN_RIGHT, 0); // highest gain
+  amac.write(AMACreg::OPAMP_GAIN_LEFT, 0); // highest gain
+  amac.write(AMACreg::HV_FREQ, 0x1);
+
+  log(logINFO) << "  ++Enable LV";
+  amac.write(AMACreg::LV_ENABLE, 0x1);
+  log(logINFO) << "  ++Disable HV";
+  amac.write(AMACreg::HV_ENABLE, 0x0);
+
+  dc.setCurrent(3);
+
+
+  log(logINFO) << "  ++ Const ADC values:";
+  unsigned ota_l, ota_r, bgo, dvdd2;
+  amac.read(AMACreg::VALUE_LEFT_CH5, ota_l);
+  std::cout << "OTA LEFT : \t" << ota_l << std::endl;
+  amac.read(AMACreg::VALUE_RIGHT_CH5, ota_r);
+  std::cout << "OTA_RIGHT : \t" << ota_r << std::endl;
+  amac.read(AMACreg::VALUE_LEFT_CH1, dvdd2);
+  std::cout << "DVDD/2 : \t" << dvdd2 << std::endl;
+  amac.read(AMACreg::VALUE_LEFT_CH2, bgo);
+  std::cout << "BGO : \t" << bgo << std::endl;
+
+
+  //
+  // Tun the reliability test
+  log(logINFO) << "Testing I2C...";
+
+  for(int i=0;i<1000;i++)
+    {
+      double result;
+      int error_ctr = 0, num_attempts_per_val=100;
+      for(int j = 0; j < num_attempts_per_val; j++)
+  	{
+  	  unsigned val_to_write = rand()%256;
+  	  unsigned val_received = 0;
+  	  //Write to any RW register
+  	  if(amac.write(AMACreg::ILOCK_HV_THRESH_HI_L_CH0,val_to_write))
+  	    {
+  	      std::cout << "Write error" << std::endl;
+  	      error_ctr++;
+  	    }
+  	  else
+  	    {
+  	      if(amac.read(AMACreg::ILOCK_HV_THRESH_HI_L_CH0,val_received))
+  		{
+  		  std::cout << "Read error" << std::endl;
+  		  error_ctr++;
+  		}
+  	      else if(val_to_write != val_received)
+  		{
+  		  std::cout << "Data error: 0x" << std::hex << val_to_write << " != 0x" << val_received << std::dec << std::endl;
+  		  error_ctr++;
+  		}
+  	    }
+  	}
+      result = 1.0 - (double)error_ctr / num_attempts_per_val;
+      std::cout << "reliability = " << result << std::endl;
+    }
+
+  //
+  // Poweroff
+  sm.turnOff();
+  ps.turnOff();
+  dc.turnOff();
+
+  return 0;
+}

--- a/src/pbv2/pbv2_poweroff.cpp
+++ b/src/pbv2/pbv2_poweroff.cpp
@@ -1,6 +1,10 @@
 #include <iostream>
 #include <cmath>
 
+#ifdef FTDI
+#include "FTDICom.h"
+#endif
+
 #include "Logger.h"
 #include "MojoCom.h"
 #include "I2CCom.h"
@@ -12,84 +16,65 @@
 loglevel_e loglevel = logINFO;
 
 int main(int argc, char* argv[]) {
+  //
+  // Get settings from the command line
+  if (argc < 4) {
+    log(logERROR) << "Not enough parameters!";
+    log(logERROR) << "Useage: " << argv[0] << " <Mojo/FTDI> <BK85XX> <GPIB>";
+    return -1;
+  }
 
-    if (argc < 4) {
-        log(logERROR) << "Not enough parameters!";
-        log(logERROR) << "Useage: " << argv[0] << " <Mojo> <BK85XX> <GPIB>";
-        return -1;
+  std::string mojoDev = argv[1];
+  std::string bkDev = argv[2];
+  std::string gpibDev = argv[3];
+
+#ifndef FTDI
+  if(mojoDev=="FTDI")
+    {
+      log(logERROR) << "FTDI support not enabled.";
+      return -1;
     }
+#endif
 
-    std::string mojoDev = argv[1];
-    std::string bkDev = argv[2];
-    std::string gpibDev = argv[3];
+  log(logINFO) << "Initialising ...";
 
-    log(logINFO) << "Initialising ...";
-    
-    log(logINFO) << " ... Agilent PS:";
-    AgilentPs ps(gpibDev, 10);
-    ps.init();
-    ps.setRange(20);
-    ps.setVoltage(11.0);
-    ps.setCurrent(2.00);
-    ps.turnOn();
+  log(logINFO) << " ... Agilent PS:";
+  AgilentPs ps(gpibDev, 10);
+  ps.init();
+  ps.setRange(20);
+  ps.setVoltage(11.0);
+  ps.setCurrent(2.00);
+  ps.turnOn();
 
-    log(logINFO) << " ... Keithley 2410:";
-    Keithley24XX sm(gpibDev, 9);
-    sm.init();
-    sm.setSource(KeithleyMode::CURRENT, 1e-6, 1e-6);
-    sm.setSense(KeithleyMode::VOLTAGE, 500, 500);
+  log(logINFO) << " ... Keithley 2410:";
+  Keithley24XX sm(gpibDev, 9);
+  sm.init();
+  sm.setSource(KeithleyMode::CURRENT, 1e-6, 1e-6);
+  sm.setSense(KeithleyMode::VOLTAGE, 500, 500);
 
-    log(logINFO) << " ... DC Load:";
-    Bk85xx dc(bkDev);
-    dc.setRemote();
-    dc.setRemoteSense();
-    dc.setModeCC();
-    dc.setCurrent(0);
-    dc.turnOn();
-  
-    log(logINFO) << " ... AMAC:";
-    MojoCom mojo(mojoDev);
-    AMAC amac(0, dynamic_cast<I2CCom*>(&mojo));
-    
+  log(logINFO) << " ... DC Load:";
+  Bk85xx dc(bkDev);
+  dc.setRemote();
+  dc.setRemoteSense();
+  dc.setModeCC();
+  dc.setCurrent(0);
+  dc.turnOn();
 
-    sm.turnOff();
-    ps.turnOff();
-    dc.turnOff();
-    
-    /*
-    log(logINFO) << "  ++ADC Values";
-    unsigned val = 0;
-    amac.read(AMACreg::VALUE_RIGHT_CH0, val);
-    log(logINFO) << "[VIN] : \t" << val ;
-    amac.read(AMACreg::VALUE_RIGHT_CH1, val);
-    log(logINFO) << "[IOUT] : \t" << val ;
-    amac.read(AMACreg::VALUE_RIGHT_CH2, val);
-    log(logINFO) << "[NTC_Temp] : \t" << val ;
-    amac.read(AMACreg::VALUE_RIGHT_CH3, val);
-    log(logINFO) << "[3R] : \t\t" << val ;
-    amac.read(AMACreg::VALUE_RIGHT_CH4, val);
-    log(logINFO) << "[VDD_H/4] : \t" << val ;
-    amac.read(AMACreg::VALUE_RIGHT_CH5, val);
-    log(logINFO) << "[OTA] : \t" << val ;
-    amac.read(AMACreg::VALUE_RIGHT_CH6, val);
-    log(logINFO) << "[ICHANR] : \t" << val ;
-    
-    amac.read(AMACreg::VALUE_LEFT_CH0, val);
-    log(logINFO) << "[0L] : \t\t" << val ;
-    amac.read(AMACreg::VALUE_LEFT_CH1, val);
-    log(logINFO) << "[DVDD/2] : \t" << val ;
-    amac.read(AMACreg::VALUE_LEFT_CH2, val);
-    log(logINFO) << "[BGO] : \t" << val ;
-    amac.read(AMACreg::VALUE_LEFT_CH3, val);
-    log(logINFO) << "[3L] : \t\t" << val ;
-    amac.read(AMACreg::VALUE_LEFT_CH4, val);
-    log(logINFO) << "[TEMP] : \t" << val ;
-    amac.read(AMACreg::VALUE_LEFT_CH5, val);
-    log(logINFO) << "[OTA] : \t" << val ;
-    amac.read(AMACreg::VALUE_LEFT_CH6, val);
-    log(logINFO) << "[ICHANL] : \t" << val ;
+  std::unique_ptr<I2CCom> i2c;
+#ifdef FTDI
+  if(mojoDev=="FTDI")
+    i2c.reset(new FTDICom());
+  else
+    i2c.reset(new MojoCom(mojoDev));
+#else
+  i2c.reset(new MojoCom(mojoDev));
+#endif
+  AMAC amac(0, i2c);
 
-    */
+  // Turn off
+  sm.turnOff();
+  ps.turnOff();
+  dc.turnOff();
 
-    return 0;
+  return 0;
 }

--- a/src/pbv2/pbv2_tester.cpp
+++ b/src/pbv2/pbv2_tester.cpp
@@ -1,5 +1,13 @@
 #include <iostream>
+#include <fstream>
 #include <cmath>
+
+#include <sys/stat.h>
+#include <dirent.h>
+
+#ifdef FTDI
+#include "FTDICom.h"
+#endif
 
 #include "Logger.h"
 #include "MojoCom.h"
@@ -12,179 +20,243 @@
 loglevel_e loglevel = logINFO;
 
 int main(int argc, char* argv[]) {
+  //
+  // Get settings from the command line
+  if (argc < 5) {
+    log(logERROR) << "Not enough parameters!";
+    log(logERROR) << "Usage: " << argv[0] << " TESTNAME <Mojo/FTDI> <BK85XX> <GPIB>";
+    return -1;
+  }
 
-    if (argc < 4) {
-        log(logERROR) << "Not enough parameters!";
-        log(logERROR) << "Useage: " << argv[0] << " <Mojo> <BK85XX> <GPIB>";
-        return -1;
+  std::string TestName = argv[1];
+  std::string mojoDev = argv[2];
+  std::string bkDev = argv[3];
+  std::string gpibDev = argv[4];
+
+#ifndef FTDI
+  if(mojoDev=="FTDI")
+    {
+      log(logERROR) << "FTDI support not enabled.";
+      return -1;
     }
-
-    std::string mojoDev = argv[1];
-    std::string bkDev = argv[2];
-    std::string gpibDev = argv[3];
-
-    log(logINFO) << "Initialising ...";
-    
-    log(logINFO) << " ... Agilent PS:";
-    AgilentPs ps(gpibDev, 10);
-    ps.init();
-    ps.setRange(20);
-    ps.setVoltage(11.0);
-    ps.setCurrent(2.00);
-    ps.turnOn();
-
-    log(logINFO) << " ... Keithley 2410:";
-    Keithley24XX sm(gpibDev, 9);
-    sm.init();
-    sm.setSource(KeithleyMode::CURRENT, 1e-6, 1e-6);
-    sm.setSense(KeithleyMode::VOLTAGE, 500, 500);
-
-    log(logINFO) << " ... DC Load:";
-    Bk85xx dc(bkDev);
-    dc.setRemote();
-    dc.setRemoteSense();
-    dc.setModeCC();
-    dc.setCurrent(0);
-    dc.turnOn();
-  
-    log(logINFO) << " ... AMAC:";
-    MojoCom mojo(mojoDev);
-    AMAC amac(0, dynamic_cast<I2CCom*>(&mojo));
-    
-    log(logINFO) << "  ++Init";
-    amac.write(AMACreg::BANDGAP_CONTROL, 10); //1.2V LDO output
-    amac.write(AMACreg::RT_CH3_GAIN_SEL, 0); // no attenuation
-    amac.write(AMACreg::LT_CH3_GAIN_SEL, 0); // no attentuation
-    amac.write(AMACreg::RT_CH0_SEL, 1); //a
-    amac.write(AMACreg::LT_CH0_SEL, 1); //a 
-    amac.write(AMACreg::LEFT_RAMP_GAIN, 3); // best range
-    amac.write(AMACreg::RIGHT_RAMP_GAIN, 3); // best range
-    amac.write(AMACreg::OPAMP_GAIN_RIGHT, 0); // highest gain
-    amac.write(AMACreg::OPAMP_GAIN_LEFT, 0); // highest gain
-    amac.write(AMACreg::HV_FREQ, 0x1);
-   
-    log(logINFO) << "  ++Enable LV";
-    amac.write(AMACreg::LV_ENABLE, 0x1);
-
-    log(logINFO) << "  ++Disable HV";
-    amac.write(AMACreg::HV_ENABLE, 0x0);
-
-   
-    log(logINFO) << "  ++ Const ADC values:";
-    unsigned ota_l, ota_r, bgo, dvdd2;
-    amac.read(AMACreg::VALUE_LEFT_CH5, ota_l);
-    std::cout << "OTA LEFT : \t" << ota_l << std::endl;
-    amac.read(AMACreg::VALUE_RIGHT_CH5, ota_r);
-    std::cout << "OTA_RIGHT : \t" << ota_r << std::endl;
-    amac.read(AMACreg::VALUE_LEFT_CH1, dvdd2);
-    std::cout << "DVDD/2 : \t" << dvdd2 << std::endl;
-    amac.read(AMACreg::VALUE_LEFT_CH2, bgo);
-    std::cout << "BGO : \t" << bgo << std::endl;
-
-    log(logINFO) << "Test LV enable: ";
-    dc.setCurrent(0);
-    dc.turnOn();
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    double lv_on = dc.getValues().vol;//mV
-    amac.write(AMACreg::LV_ENABLE, 0x0);
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    double lv_off = dc.getValues().vol;//mV
-    amac.write(AMACreg::LV_ENABLE, 0x1);
-    if (!(lv_on > 1.4e3 && lv_on < 1.6e3 && lv_off < 0.1e3)) {
-        log(logERROR) << " ++ LV enable not working! " << lv_on << " " << lv_off;
-        return -1;
-    } else {
-        log(logINFO) << " ++ LV enable good!";
-    }
-
-#if 0
-    log(logINFO) << "Test HV enable: ";
-    sm.setSource(KeithleyMode::CURRENT, 1e-6, 1e-6);
-    sm.setSense(KeithleyMode::VOLTAGE, 100, 100);
-    sm.turnOn();
-    std::this_thread::sleep_for(std::chrono::seconds(2));
-    double hv_off = std::stod(sm.sense().substr(0,13));
-    amac.write(AMACreg::HV_ENABLE, 0x1);
-    std::this_thread::sleep_for(std::chrono::seconds(2));
-    double hv_on = std::stod(sm.sense().substr(0,13));
-    // If HVmux does not conduct, source meter will go into compliance
-    if (!(hv_off > 90.0 && hv_on < 1.0)) {
-        log(logERROR) << " ++ HV enable not working! " << hv_off << " " << hv_on;
-        return -1;
-    } else {
-        log(logINFO) << " ++ HV enable good!";
-    }
-    sm.turnOff();
 #endif
 
-    log(logINFO) << "Testing Current Sense Amp & Efficiency...";
-    double iout_min = 0;
-    double iout_max = 4000;
-    double iout_step = 100;
-
-    for (double iout = iout_min; iout <= iout_max; iout+=iout_step) {
-        dc.setCurrent(iout);
-        std::this_thread::sleep_for(std::chrono::seconds(10));
-        unsigned cur = 0;
-        amac.read(AMACreg::VALUE_RIGHT_CH1, cur);
-        unsigned ptat = 0;
-        amac.read(AMACreg::VALUE_RIGHT_CH3, ptat);
-        unsigned ntc = 0;
-        amac.read(AMACreg::VALUE_RIGHT_CH2, ntc);
-        std::cout << iout << "\t" << dc.getValues().vol << "\t" << cur << "\t" << ps.getCurrent() << "\t" << ntc << "\t" << ptat << std::endl;
+  //
+  // Create log directory if it does not exist
+  DIR* logdir=opendir("log");
+  if(!logdir)
+    {
+      const int dir_err = mkdir("log", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+      if (-1 == dir_err)
+	{
+	  std::cerr << "Error creating log directory!" << std::endl;
+	  return 1;
+	}
     }
-    dc.setCurrent(1000);
+  else
+    closedir(logdir);
 
-    log(logINFO) << "Testing VIN measurement ...";
-    double vin_min = 6.0;
-    double vin_max = 12.0;
-    double vin_step = 0.1;
-
-    for (double vin=vin_min; vin<=vin_max; vin+=vin_step) {
-        ps.setVoltage(vin);
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-        unsigned val = 0;
-        amac.read(AMACreg::VALUE_RIGHT_CH0, val);
-        std::cout << vin << "\t" << val << std::endl;
-    }
-    ps.setVoltage(11.0);
-    ps.setCurrent(2.00);
-
-
-    log(logINFO) << "Testing Ileak measurement ...";
-    amac.write(AMACreg::HV_ENABLE, 0x1);
-    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
-    double ileak_min = 1e-6;
-    double ileak_max = 1e-3;
-    double ileak_step = 1e-6;
-    sm.setSource(KeithleyMode::CURRENT, ileak_min, ileak_min);
-    sm.turnOn();
-
-    int counter = 0;
-    for (double ileak=ileak_min; ileak<=ileak_max; ileak += ileak_step) {
-        counter++;
-        if (counter%10 == 0)
-            ileak_step = ileak_step*10;
-        sm.setSource(KeithleyMode::CURRENT, ileak, ileak);
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-        unsigned val[5];
-        for (unsigned i=0; i<5; i++) {
-            if (i == 0) {
-                amac.write(AMACreg::OPAMP_GAIN_LEFT, 0);
-            } else {
-                amac.write(AMACreg::OPAMP_GAIN_LEFT, pow(2,i-1));
-            }
-
-            std::this_thread::sleep_for(std::chrono::milliseconds(500));
-            amac.read(AMACreg::VALUE_LEFT_CH6, *&val[i]);
-        }
-        std::cout << ileak << "\t" << val[0] << "\t" << val[1] << "\t" << val[2] << "\t" << val[3] << "\t" << val[4] << std::endl;
-    }
-    sm.turnOff();
-    ps.turnOff();
-    dc.turnOff();
+  //
+  // Run tests
+  log(logINFO) << "Initialising ...";
     
-    /*
+  log(logINFO) << " ... Agilent PS:";
+  AgilentPs ps(gpibDev, 10);
+  ps.init();
+  ps.setRange(20);
+  ps.setVoltage(11.0);
+  ps.setCurrent(2.00);
+  ps.turnOn();
+
+  log(logINFO) << " ... Keithley 2410:";
+  Keithley24XX sm(gpibDev, 9);
+  sm.init();
+  sm.setSource(KeithleyMode::CURRENT, 1e-6, 1e-6);
+  sm.setSense(KeithleyMode::VOLTAGE, 500, 500);
+
+  log(logINFO) << " ... DC Load:";
+  Bk85xx dc(bkDev);
+  dc.setRemote();
+  dc.setRemoteSense();
+  dc.setModeCC();
+  dc.setCurrent(0);
+  dc.turnOn();
+
+  std::unique_ptr<I2CCom> i2c;
+#ifdef FTDI
+  if(mojoDev=="FTDI")
+    i2c.reset(new FTDICom());
+  else
+    i2c.reset(new MojoCom(mojoDev));
+#else
+  i2c.reset(new MojoCom(mojoDev));
+#endif
+  AMAC amac(0, i2c);
+
+  log(logINFO) << "  ++Init";
+  amac.write(AMACreg::BANDGAP_CONTROL, 10); //1.2V LDO output
+  amac.write(AMACreg::RT_CH3_GAIN_SEL, 0); // no attenuation
+  amac.write(AMACreg::LT_CH3_GAIN_SEL, 0); // no attentuation
+  amac.write(AMACreg::RT_CH0_SEL, 1); //a
+  amac.write(AMACreg::LT_CH0_SEL, 1); //a 
+  amac.write(AMACreg::LEFT_RAMP_GAIN, 3); // best range
+  amac.write(AMACreg::RIGHT_RAMP_GAIN, 3); // best range
+  amac.write(AMACreg::OPAMP_GAIN_RIGHT, 0); // highest gain
+  amac.write(AMACreg::OPAMP_GAIN_LEFT, 0); // highest gain
+  amac.write(AMACreg::HV_FREQ, 0x1);
+
+  log(logINFO) << "  ++Enable LV";
+  amac.write(AMACreg::LV_ENABLE, 0x1);
+  sleep(10);
+  log(logINFO) << "  ++Disable HV";
+  amac.write(AMACreg::HV_ENABLE, 0x0);
+
+
+  log(logINFO) << "  ++ Const ADC values:";
+  unsigned ota_l, ota_r, bgo, dvdd2;
+  amac.read(AMACreg::VALUE_LEFT_CH5, ota_l);
+  std::cout << "OTA LEFT : \t" << ota_l << std::endl;
+  amac.read(AMACreg::VALUE_RIGHT_CH5, ota_r);
+  std::cout << "OTA_RIGHT : \t" << ota_r << std::endl;
+  amac.read(AMACreg::VALUE_LEFT_CH1, dvdd2);
+  std::cout << "DVDD/2 : \t" << dvdd2 << std::endl;
+  amac.read(AMACreg::VALUE_LEFT_CH2, bgo);
+  std::cout << "BGO : \t" << bgo << std::endl;
+
+  log(logINFO) << "Test LV enable: ";
+  dc.setCurrent(0);
+  dc.turnOn();
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  double lv_on = dc.getValues().vol;//mV
+  amac.write(AMACreg::LV_ENABLE, 0x0);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  double lv_off = dc.getValues().vol;//mV
+  amac.write(AMACreg::LV_ENABLE, 0x1);
+
+  if (!(lv_on > 1.4e3 && lv_on < 1.6e3 && lv_off < 0.1e3)) {
+    log(logERROR) << " ++ LV enable not working! " << lv_on << " " << lv_off;
+    return -1;
+  } else {
+    log(logINFO) << " ++ LV enable good!";
+  }
+
+#if 0
+  log(logINFO) << "Test HV enable: ";
+  sm.setSource(KeithleyMode::CURRENT, 1e-6, 1e-6);
+  sm.setSense(KeithleyMode::VOLTAGE, 100, 100);
+  sm.turnOn();
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  double hv_off = std::stod(sm.sense().substr(0,13));
+  amac.write(AMACreg::HV_ENABLE, 0x1);
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  double hv_on = std::stod(sm.sense().substr(0,13));
+  // If HVmux does not conduct, source meter will go into compliance
+  if (!(hv_off > 90.0 && hv_on < 1.0)) {
+    log(logERROR) << " ++ HV enable not working! " << hv_off << " " << hv_on;
+    return -1;
+  } else {
+    log(logINFO) << " ++ HV enable good!";
+  }
+  sm.turnOff();
+#endif
+
+  //
+  // Testing Current Sense Amp & Efficiency...
+  log(logINFO) << "Testing Current Sense Amp & Efficiency...";
+
+  std::string logpath = "log/" + TestName + "_DCDCEfficiency.log";
+  std::fstream logfile(logpath, std::fstream::out);
+  logfile << "Iout Vout Iin Vin IoutADC ntc ptat" << std::endl;
+
+  double iout_min = 0;
+  double iout_max = 4000;
+  double iout_step = 100;
+
+  for (double iout = iout_min; iout <= iout_max; iout+=iout_step) {
+    dc.setCurrent(iout);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+    unsigned cur = 0;
+    amac.read(AMACreg::VALUE_RIGHT_CH1, cur);
+    unsigned ptat = 0;
+    amac.read(AMACreg::VALUE_RIGHT_CH3, ptat);
+    unsigned ntc = 0;
+    amac.read(AMACreg::VALUE_RIGHT_CH2, ntc);
+    std::cout << iout << "\t" << dc.getValues().vol << "\t" << cur << "\t" << ps.getCurrent() << "\t" << ntc << "\t" << ptat << std::endl;
+    logfile << iout << " " << dc.getValues().vol << " " << ps.getCurrent() << " " << ps.getVoltage() << " " << cur << " " << ntc << " " << ptat << std::endl;
+  }
+  dc.setCurrent(1000);
+  logfile.close();
+
+  //
+  // Testing VIN measurement
+  log(logINFO) << "Testing VIN measurement ...";
+
+  logpath = "log/" + TestName + "_VIN.log";
+  logfile.open(logpath, std::fstream::out);
+  logfile << "Vin VinADC" << std::endl;
+
+  double vin_min = 6.0;
+  double vin_max = 12.0;
+  double vin_step = 0.1;
+
+  for (double vin=vin_min; vin<=vin_max; vin+=vin_step) {
+    ps.setVoltage(vin);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    unsigned val = 0;
+    amac.read(AMACreg::VALUE_RIGHT_CH0, val);
+    std::cout << vin << "\t" << val << std::endl;
+    logfile << vin << " " << val << std::endl;
+  }
+  ps.setVoltage(11.0);
+  ps.setCurrent(2.00);
+  logfile.close();
+
+  //
+  // Testing Ileak measurement
+  log(logINFO) << "Testing Ileak measurement ...";
+
+  logpath = "log/" + TestName + "_Ileak.log";
+  logfile.open(logpath, std::fstream::out);
+  logfile << "Ileak OpAmpGain0 OpAmpGain1 OpAmpGain2 OpAmpGain4 OpAmpGain8" << std::endl;
+
+  amac.write(AMACreg::HV_ENABLE, 0x1);
+  std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+  double ileak_min = 1e-6;
+  double ileak_max = 1e-3;
+  double ileak_step = 1e-6;
+  sm.setSource(KeithleyMode::CURRENT, ileak_min, ileak_min);
+  sm.turnOn();
+
+  int counter = 0;
+  for (double ileak=ileak_min; ileak<=ileak_max; ileak += ileak_step) {
+      counter++;
+      if (counter%10 == 0)
+          ileak_step = ileak_step*10;
+      sm.setSource(KeithleyMode::CURRENT, ileak, ileak);
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+      unsigned val[5];
+      for (unsigned i=0; i<5; i++) {
+          if (i == 0) {
+              amac.write(AMACreg::OPAMP_GAIN_LEFT, 0);
+          } else {
+              amac.write(AMACreg::OPAMP_GAIN_LEFT, pow(2,i-1));
+          }
+
+          std::this_thread::sleep_for(std::chrono::milliseconds(500));
+          amac.read(AMACreg::VALUE_LEFT_CH6, *&val[i]);
+      }
+      std::cout << ileak << "\t" << val[0] << "\t" << val[1] << "\t" << val[2] << "\t" << val[3] << "\t" << val[4] << std::endl;
+      logfile << ileak << " " << val[0] << " " << val[1] << " " << val[2] << " " << val[3] << " " << val[4] << std::endl;
+  }
+
+  //
+  // Power-off
+  sm.turnOff();
+  ps.turnOff();
+  dc.turnOff();
+    
+  /*
     log(logINFO) << "  ++ADC Values";
     unsigned val = 0;
     amac.read(AMACreg::VALUE_RIGHT_CH0, val);


### PR DESCRIPTION
This adds an implementation of the I2CCom interface using the FT232H dongle. It depends on the following two libraries:

- [libftdi](https://www.intra2net.com/en/developer/libftdi/download.php) - Generic FTDI library
- [libmpsse](https://github.com/l29ah/libmpsse) - Library that implements common communication protocols (I2C, SPI) using the MPSSE framework on FTDI chips